### PR TITLE
Apply steel gradient style to all cards

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -118,15 +118,15 @@ svg {
 }
 
 .glass-bg {
-  background-color: rgba(
-    255,
-    255,
-    255,
-    0.4
-  ); /* 40% opacity for better contrast */
+  background-image: linear-gradient(
+    135deg,
+    rgba(90, 96, 108, 0.55),
+    rgba(60, 64, 72, 0.55),
+    rgba(30, 32, 40, 0.55)
+  );
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .text-glass-shadow {

--- a/src/components/blog-card/index.tsx
+++ b/src/components/blog-card/index.tsx
@@ -39,7 +39,7 @@ const BlogCard = ({
     for (let index = 0; index < blog.limit; index++) {
       array.push(
         <div
-          className="card shadow-lg compact bg-base-100 bg-opacity-40 backdrop-blur-sm transition-all duration-300"
+          className="card glass-bg shadow-lg compact transition-all duration-300"
           key={index}
         >
           <div className="p-8 h-full w-full">
@@ -98,7 +98,7 @@ const BlogCard = ({
     return articles && articles.length ? (
       articles.slice(0, blog.limit).map((article, index) => (
         <a
-          className="card shadow-lg compact bg-base-100 bg-opacity-40 backdrop-blur-sm transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
+          className="card glass-bg shadow-lg compact transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
           key={index}
           href={article.link}
           onClick={(e) => {
@@ -177,13 +177,7 @@ const BlogCard = ({
     <div className="col-span-1 lg:col-span-2">
       <div className="grid grid-cols-2 gap-6">
         <div className="col-span-2">
-          <div
-            className={`card compact bg-base-100 ${
-              loading || (articles && articles.length)
-                ? 'shadow-lg bg-opacity-40 backdrop-blur-sm'
-                : 'shadow-lg'
-            }`}
-          >
+          <div className="card glass-bg shadow-lg compact">
             <div className="card-body">
               <div className="mx-3 mb-4">
                 <h5 className="card-title text-2xl font-bold">

--- a/src/components/experience-card/index.tsx
+++ b/src/components/experience-card/index.tsx
@@ -58,7 +58,7 @@ const ExperienceCard = ({
     return array;
   };
   return (
-    <div className="card shadow-lg compact bg-base-100">
+    <div className="card glass-bg shadow-lg compact">
       <div className="card-body">
         <div className="mx-3">
           <h5 className="card-title">

--- a/src/components/github-project-card/index.tsx
+++ b/src/components/github-project-card/index.tsx
@@ -29,7 +29,7 @@ const GithubProjectCard = ({
     for (let index = 0; index < limit; index++) {
       array.push(
         <div
-          className="card bg-base-200 bg-opacity-50 backdrop-blur-sm border border-base-300"
+          className="card glass-bg border border-base-300"
           key={index}
         >
           <div className="flex justify-between flex-col p-6 h-full w-full">
@@ -80,7 +80,7 @@ const GithubProjectCard = ({
   const renderProjects = () => {
     return githubProjects.map((item, index) => (
       <a
-        className="card bg-base-200 bg-opacity-50 backdrop-blur-sm border border-base-300 hover:border-primary hover:shadow-lg transition-all duration-300 cursor-pointer group"
+        className="card glass-bg border border-base-300 hover:border-primary hover:shadow-lg transition-all duration-300 cursor-pointer group"
         href={item.html_url}
         key={index}
         onClick={(e) => {

--- a/src/components/live-projects-card/index.tsx
+++ b/src/components/live-projects-card/index.tsx
@@ -28,7 +28,7 @@ const LiveProjectsCard = ({ loading, projects }: LiveProjectsCardProps) => {
             {[1, 2].map((index) => (
               <div
                 key={index}
-                className="card bg-base-200 bg-opacity-50 backdrop-blur-sm border border-base-300"
+                className="card glass-bg border border-base-300"
               >
                 <div className="card-body">
                   {skeleton({ widthCls: 'w-24', heightCls: 'h-6' })}
@@ -62,7 +62,7 @@ const LiveProjectsCard = ({ loading, projects }: LiveProjectsCardProps) => {
             {projects.map((project, index) => (
               <a
                 key={index}
-                className="card bg-base-200 bg-opacity-50 backdrop-blur-sm border border-base-300 hover:border-primary hover:shadow-lg transition-all duration-300 cursor-pointer group"
+                className="card glass-bg border border-base-300 hover:border-primary hover:shadow-lg transition-all duration-300 cursor-pointer group"
                 href={project.link}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/publication-card/index.tsx
+++ b/src/components/publication-card/index.tsx
@@ -15,7 +15,7 @@ const PublicationCard = ({
     for (let index = 0; index < publications.length; index++) {
       array.push(
         <div
-          className="card bg-base-200 bg-opacity-50 backdrop-blur-sm border border-base-300"
+          className="card glass-bg border border-base-300"
           key={index}
         >
           <div className="p-6 h-full w-full">
@@ -66,7 +66,7 @@ const PublicationCard = ({
   const renderPublications = () => {
     return publications.map((item, index) => (
       <a
-        className="card bg-base-200 bg-opacity-50 backdrop-blur-sm border border-base-300 hover:border-primary hover:shadow-lg transition-all duration-300 cursor-pointer group"
+        className="card glass-bg border border-base-300 hover:border-primary hover:shadow-lg transition-all duration-300 cursor-pointer group"
         key={index}
         href={item.link}
         target="_blank"


### PR DESCRIPTION
## Summary
- overhaul card design with new steel gradient glass look
- swap individual backgrounds with `glass-bg` utility

## Testing
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684641080e988320a1f313de47a60187