### PR TITLE
Fix podcast link pill text color

### DIFF
--- a/src/components/podcast-card/index.tsx
+++ b/src/components/podcast-card/index.tsx
@@ -41,7 +41,7 @@ const ListItem = ({
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-accent-content bg-primary bg-opacity-10 rounded-full transition-all duration-300 hover:bg-opacity-20 hover:scale-105"
+              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-base-content-important bg-primary bg-opacity-10 rounded-full transition-all duration-300 hover:bg-opacity-20 hover:scale-105"
             >
               <FaPodcast className="mr-1.5" />
               {link.name}


### PR DESCRIPTION
## Summary
- ensure podcast links have white text across themes

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846481720ec832084cc01a2a5573b4b