### PR TITLE
Fix Live Projects card width on mobile

### DIFF
--- a/src/components/gitprofile.tsx
+++ b/src/components/gitprofile.tsx
@@ -282,12 +282,14 @@ const GitProfile = ({ config }: { config: Config }) => {
                     {sanitizedConfig.projects.liveProjects.display &&
                       sanitizedConfig.projects.liveProjects.projects.length >
                         0 && (
-                        <LiveProjectsCard
-                          loading={loading}
-                          projects={
-                            sanitizedConfig.projects.liveProjects.projects
-                          }
-                        />
+                        <div className="col-span-2">
+                          <LiveProjectsCard
+                            loading={loading}
+                            projects={
+                              sanitizedConfig.projects.liveProjects.projects
+                            }
+                          />
+                        </div>
                       )}
                     {/* GitHub Contribution Graph Card - spans both columns */}
                     <div className="col-span-2">


### PR DESCRIPTION
## Summary
- ensure Live Projects card spans full width like other cards on small screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846f3f554848320ae62ad527a510dd6