### PR TITLE
Enable rounded edges across all themes

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -140,4 +140,7 @@ svg {
 /* Force text color to white across all DaisyUI themes */
 [data-theme] {
   --bc: 0 0% 100% !important;
+  /* Ensure cards and buttons have rounded corners across all themes */
+  --rounded-box: 1rem !important;
+  --rounded-btn: 0.5rem !important;
 }


### PR DESCRIPTION
## Summary
- globally apply DaisyUI rounded variables so every theme has soft card corners

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68476f21600c8320b3535b8454e4fcd7